### PR TITLE
More fine grained branch entropy measurement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,9 +71,10 @@ include_directories(${LLVM_INCLUDE_DIRS})
 link_directories(${LLVM_LIBRARY_DIRS})
 
 #to build against a shared version of LLVM:
-exec_program("${CLANG_ROOT}/bin/llvm-config --libfiles"
+exec_program("${CLANG_ROOT}/bin/llvm-config --libfiles --system-libs"
     WORKING_DIRECTORY ${CLANG_ROOT}/bin/llvm-config
     OUTPUT_VARIABLE LLVM_LIBS)
+string(REGEX REPLACE "\n" " " LLVM_LIBS "${LLVM_LIBS}")
 separate_arguments(LLVM_LIBS)
 add_compile_definitions(LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1)
 message("llvm libs are now: ${LLVM_LIBS}")

--- a/src/plugins/WorkloadCharacterisation.cpp
+++ b/src/plugins/WorkloadCharacterisation.cpp
@@ -30,7 +30,7 @@
 #include "llvm/Support/raw_ostream.h"
 
 using namespace oclgrind;
-using namespace std;  
+using namespace std;
 
 #define COUNTED_LOAD_BASE (llvm::Instruction::OtherOpsEnd + 4)
 #define COUNTED_STORE_BASE (COUNTED_LOAD_BASE + 8)
@@ -112,9 +112,9 @@ void WorkloadCharacterisation::threadMemoryLedger(size_t address, uint32_t times
   WorkloadCharacterisation::ledgerElement le;
   le.address = address;
   le.timestep = timestep;
-  (m_state.ledger)//[groupID.x * m_group_num.x + groupID.y * m_group_num.y 
+  (m_state.ledger)//[groupID.x * m_group_num.x + groupID.y * m_group_num.y
         // + groupID.z * m_group_num.z]
-        [localID.x * m_local_num.y * m_local_num.z + localID.y * m_local_num.z 
+        [localID.x * m_local_num.y * m_local_num.z + localID.y * m_local_num.z
          + localID.z].push_back(le);
 }
 
@@ -122,7 +122,7 @@ void WorkloadCharacterisation::memoryLoad(const Memory *memory, const WorkItem *
   if (memory->getAddressSpace() != AddrSpacePrivate) {
     //(*m_state.memoryOps)[pair(address, true)]++;
     (*m_state.loadOps)[address]++;
-    threadMemoryLedger(address, 0, workItem->getLocalID()); 
+    threadMemoryLedger(address, 0, workItem->getLocalID());
   }
 }
 
@@ -130,7 +130,7 @@ void WorkloadCharacterisation::memoryStore(const Memory *memory, const WorkItem 
   if (memory->getAddressSpace() != AddrSpacePrivate) {
     //(*m_state.memoryOps)[pair(address, false)]++;
     (*m_state.storeOps)[address]++;
-    threadMemoryLedger(address, 0, workItem->getLocalID()); 
+    threadMemoryLedger(address, 0, workItem->getLocalID());
   }
 }
 
@@ -201,17 +201,14 @@ void WorkloadCharacterisation::instructionExecuted(
 
   //collect conditional branches and the associated trace to count which ones were taken and which weren't
   if (m_state.previous_instruction_is_branch == true) {
-    std::string Str;
-    llvm::raw_string_ostream OS(Str);
-    instruction->getParent()->printAsOperand(OS, false);
-    OS.flush();
-    if (Str == m_state.target1)
+    const llvm::BasicBlock* bb = instruction->getParent();
+    if (bb == m_state.target1)
       (*m_state.branchOps)[m_state.branch_loc].push_back(true); //taken
-    else if (Str == m_state.target2) {
+    else if (bb == m_state.target2) {
       (*m_state.branchOps)[m_state.branch_loc].push_back(false); //not taken
     } else {
       cout << "Error in branching!" << endl;
-      cout << "Str was: " << Str << " but target was either: " << m_state.target1 << " or: " << m_state.target2 << endl;
+      cout << "Instruction ptr is " << (int*) bb << " but target was either " << (int*) m_state.target1 << " or " << (int*) m_state.target2 << endl;
       std::raise(SIGINT);
     }
     m_state.previous_instruction_is_branch = false;
@@ -220,17 +217,9 @@ void WorkloadCharacterisation::instructionExecuted(
   if (opcode == llvm::Instruction::Br && instruction->getNumOperands() == 3) {
     if (instruction->getOperand(1)->getType()->isLabelTy() && instruction->getOperand(2)->getType()->isLabelTy()) {
       m_state.previous_instruction_is_branch = true;
-      std::string Str;
-      llvm::raw_string_ostream OS(Str);
-      instruction->getOperand(1)->printAsOperand(OS, false);
-      OS.flush();
-      m_state.target1 = Str;
-      Str = "";
-      instruction->getOperand(2)->printAsOperand(OS, false);
-      OS.flush();
-      m_state.target2 = Str;
-      llvm::DebugLoc loc = instruction->getDebugLoc();
-      m_state.branch_loc = loc.getLine();
+      m_state.target1 = (llvm::BasicBlock*) instruction->getOperand(1);
+      m_state.target2 = (llvm::BasicBlock*) instruction->getOperand(2);
+      m_state.branch_loc = instruction;
     }
   }
 
@@ -272,7 +261,7 @@ void WorkloadCharacterisation::workItemBegin(const WorkItem *workItem) {
   m_state.workitem_instruction_count = 0;
   m_state.ops_between_load_or_store = 0;
   //Size_3 local_ID = workItem->getLocalID;
-  //m_state.work_item_no = localID.x * m_local_num.y * m_local_num.z + localID.y * m_local_num.z 
+  //m_state.work_item_no = localID.x * m_local_num.y * m_local_num.z + localID.y * m_local_num.z
   //       + localID.z;
   //m_state.work_group_no = 0;
 }
@@ -351,7 +340,7 @@ vector<double> parallelSpatialLocality(vector < vector < WorkloadCharacterisatio
   size_t maxLength = 0;
   for (size_t i = 0; i < hist.size(); i++)
     maxLength = hist[i].size() > maxLength ? hist[i].size() : maxLength;
-  
+
   unordered_map <size_t, uint32_t> histogram;
   vector<vector<double>> entropies = vector<vector<double>>(maxLength);
 
@@ -369,7 +358,7 @@ vector<double> parallelSpatialLocality(vector < vector < WorkloadCharacterisatio
 
   vector<double> psl = vector<double>(11, 0.0);
   for (uint32_t i = 0; i < 11; i++) {
-    for (size_t j = 0; j < entropies.size(); j++) 
+    for (size_t j = 0; j < entropies.size(); j++)
       psl[i] += entropies[j][i];
     psl[i] = psl[i] * 1.0/ ((double)entropies.size() + 1);
   }
@@ -505,7 +494,7 @@ void WorkloadCharacterisation::kernelEnd(const KernelInvocation *kernelInvocatio
   uint16_t simd_min = std::min_element(m_instructionWidth.begin(), m_instructionWidth.end(), [](const pair_type &a, const pair_type &b) { return a.first < b.first; })->first;
   uint16_t simd_max = std::max_element(m_instructionWidth.begin(), m_instructionWidth.end(), [](const pair_type &a, const pair_type &b) { return a.first < b.first; })->first;
 
-  uint32_t simd_sum = 0;  
+  uint32_t simd_sum = 0;
   uint32_t simd_num = 0;
   for (const auto &item : m_instructionWidth) {
     simd_sum += item.second * item.first;
@@ -573,7 +562,7 @@ void WorkloadCharacterisation::kernelEnd(const KernelInvocation *kernelInvocatio
   cout << "Total Memory Footprint -- num unique memory addresses accessed: " << local_address_count[0].size() << endl;
   cout << "                          num unique memory addresses read:     " << m_storeOps.size() << endl;
   cout << "                          num unique memory addresses written:  " << m_loadOps.size()  << endl;
-  cout << "                          unique read/write ratio:              " 
+  cout << "                          unique read/write ratio:              "
        << setprecision(4) << (float) (((double)m_loadOps.size()) / ((double)m_storeOps.size()))  << endl;
   cout << "                          total reads:                          " << load_count    << endl;
   cout << "                          total writes:                         " << store_count    << endl;
@@ -631,7 +620,7 @@ void WorkloadCharacterisation::kernelEnd(const KernelInvocation *kernelInvocatio
   cout << endl
        << "### Parallel Spatial Locality" << endl
        << endl;
-  
+
 
   cout << "|" << setw(12) << right << "LSBs skipped"
        << "|" << setw(25) << right << "Normed Parallel Spatial Locality"
@@ -799,7 +788,7 @@ void WorkloadCharacterisation::kernelEnd(const KernelInvocation *kernelInvocatio
   logfile << "Unique Memory Accesses,Memory," << local_address_count[0].size() << "\n";
   logfile << "Unique Reads,Memory," << m_storeOps.size() << "\n";
   logfile << "Unique Writes,Memory," << m_loadOps.size()  << "\n";
-  logfile << "Unique Read/Write Ratio,Memory," 
+  logfile << "Unique Read/Write Ratio,Memory,"
        << setprecision(4) << (float) (((double)m_loadOps.size()) / ((double)m_storeOps.size()))  << "\n";
   logfile << "Total Reads,Memory," << load_count    << "\n";
   logfile << "Total Writes,Memory," << store_count    << "\n";
@@ -854,7 +843,7 @@ void WorkloadCharacterisation::workGroupBegin(const WorkGroup *workGroup) {
     m_state.storeOps = new unordered_map<size_t, uint32_t>;
     m_state.loadOps = new unordered_map<size_t, uint32_t>;
     m_state.computeOps = new unordered_map<std::string, size_t>;
-    m_state.branchOps = new unordered_map<size_t, std::vector<bool>>;
+    m_state.branchOps = new unordered_map<const llvm::Instruction*, std::vector<bool>>;
     m_state.instructionsBetweenBarriers = new vector<uint32_t>;
     m_state.instructionWidth = new unordered_map<uint16_t, size_t>;
     m_state.instructionsPerWorkitem = new vector<uint32_t>;
@@ -889,9 +878,9 @@ void WorkloadCharacterisation::workGroupBegin(const WorkGroup *workGroup) {
 
   //branch logic variables
   m_state.previous_instruction_is_branch = false;
-  m_state.target1 = "";
-  m_state.target2 = "";
-  m_state.branch_loc = 0;
+  m_state.target1 = nullptr;
+  m_state.target2 = nullptr;
+  m_state.branch_loc = nullptr;
 
   for (size_t i = 0; i < (m_state.ledger).size(); i++)
     (m_state.ledger)[i].clear();
@@ -914,10 +903,24 @@ void WorkloadCharacterisation::workGroupComplete(const WorkGroup *workGroup) {
   for (auto const &item : (*m_state.loadOps))
     m_loadOps[item.first] += item.second;
 
+
+
   // merge control operations into global unordered maps
+  bool notified_missing_debug_info = false;
   const unsigned m = 16;
   for (auto const &branch : (*m_state.branchOps)) {
-    m_branchCounts[branch.first] += branch.second.size();
+    size_t instruction_line = 0;
+
+    const llvm::Instruction *instruction = branch.first;
+    const llvm::DebugLoc& loc = instruction->getDebugLoc();
+    if (loc) {
+      instruction_line = loc.getLine();
+    } else if (!notified_missing_debug_info) {
+      std::cerr << "Missing debug info for kernel" << std::endl;
+      notified_missing_debug_info = true;
+    }
+
+    m_branchCounts[instruction_line] += branch.second.size();
 
     // compute branch patterns
     //if we have fewer branches than the history window, skip it.
@@ -932,7 +935,7 @@ void WorkloadCharacterisation::workGroupComplete(const WorkGroup *workGroup) {
       current_pattern = (current_pattern << 1) | (b ? 1 : 0);
       if (i >= m - 1) {
         // we now have m bits of pattern to compare
-        m_branchPatterns[branch.first][current_pattern]++;
+        m_branchPatterns[instruction_line][current_pattern]++;
       }
     }
   }
@@ -975,7 +978,7 @@ void WorkloadCharacterisation::workGroupComplete(const WorkGroup *workGroup) {
     maxLength = m_state.ledger[i].size() > maxLength ? m_state.ledger[i].size() : maxLength;
     m_state.ledger[i].clear();
   }
-  
+
   m_state.psl_per_barrier->push_back(std::make_pair(psl, maxLength));
 
   maxLength = 0;
@@ -990,8 +993,7 @@ void WorkloadCharacterisation::workGroupComplete(const WorkGroup *workGroup) {
   if (maxLength != 0) {
     for (size_t nskip = 0; nskip < 11; nskip++) {
       weighted_avg_psl[nskip] = weighted_avg_psl[nskip] / static_cast<float>(maxLength + 1);
-    }   
+    }
   }
-  m_psl_per_group.push_back(weighted_avg_psl);  
+  m_psl_per_group.push_back(weighted_avg_psl);
 }
-

--- a/src/plugins/WorkloadCharacterisation.h
+++ b/src/plugins/WorkloadCharacterisation.h
@@ -42,7 +42,7 @@ public:
   virtual void workItemComplete(const WorkItem *workItem) override;
   virtual void workItemBarrier(const WorkItem *workItem) override;
   virtual void workItemClearBarrier(const WorkItem *workItem) override;
-  
+
   struct ledgerElement {
     size_t address;
     uint32_t timestep;
@@ -80,9 +80,9 @@ private:
     std::unordered_map<size_t, uint32_t> *loadOps;
     // true -> load; false -> store.
     bool previous_instruction_is_branch;
-    std::string target1, target2;
-    uint32_t branch_loc;
-    std::unordered_map<size_t, std::vector<bool>> *branchOps;
+    llvm::BasicBlock *target1, *target2;
+    const llvm::Instruction *branch_loc;
+    std::unordered_map<const llvm::Instruction*, std::vector<bool>> *branchOps;
     uint32_t threads_invoked;
     uint32_t barriers_hit;
     uint32_t instruction_count;


### PR DESCRIPTION
Changes the branch entropy calculation to track branch locations by instruction instead of by source line of instruction. This means that branches instructions that would have shared the same source line are now tracked separately. Originally both instructions would have been appending taken/not taken to the same list.

This will change the entropy values, as the patterns are now different.

It also means we don't depend on debug information, which is not guaranteed when receiving precompiled programs.

The branch source line is still used in the branch count stats where possible, and defaults to line 0 when not (it will also print a warning that debug info is missing).


I also had to add `--system-libs` to the `llvm-config` call, as `dlopen` and co. weren't being linked otherwise. 