### PR TITLE
Configure Oclgrind device type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ config.h
 .ninja_log
 build.ninja
 rules.ninja
+build
 
 # Compiler output
 *.o

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,7 +259,7 @@ set_target_properties(oclgrind PROPERTIES INSTALL_RPATH ${CLANG_ROOT}/lib)
 target_link_libraries(oclgrind PUBLIC ${CORE_EXTRA_LIBS} -Wl,-rpath,${CLANG_ROOT}/lib
   clangFrontend clangSerialization clangDriver clangCodeGen
   clangParse clangSema clangAnalysis clangEdit clangAST clangLex clangBasic
-  "${LLVM_LIBS}" Threads::Threads)
+  "${LLVM_LIBS}" Threads::Threads dl)
 
 if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
   target_link_libraries(oclgrind PRIVATE Version)


### PR DESCRIPTION
Builds on #4 

From https://github.com/Aerijo/AIWC/pull/2

SYCL isn't clear on if the device type is a plain enum or a bitfield. OpenCL supports a bitfield, and Oclgrind sets itself as all device types. This confuses DPC++, which doesn't detect it as anything.

It's also generally useful to be able to set the device type, as certain programs may pick a different kernel depending on the device. This allows both paths to be tested.

Config is through OCLGRIND_DEVICE_TYPE env variable. It is a semicolon separated list of device types (all caps). Not setting a type, or using ALL, will use the original Oclgrind device type.