### PR TITLE
Fix branch entropy calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ config.h
 .ninja_log
 build.ninja
 rules.ninja
+build
 
 # Compiler output
 *.o

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,7 +259,7 @@ set_target_properties(oclgrind PROPERTIES INSTALL_RPATH ${CLANG_ROOT}/lib)
 target_link_libraries(oclgrind PUBLIC ${CORE_EXTRA_LIBS} -Wl,-rpath,${CLANG_ROOT}/lib
   clangFrontend clangSerialization clangDriver clangCodeGen
   clangParse clangSema clangAnalysis clangEdit clangAST clangLex clangBasic
-  "${LLVM_LIBS}" Threads::Threads)
+  "${LLVM_LIBS}" Threads::Threads dl)
 
 if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
   target_link_libraries(oclgrind PRIVATE Version)

--- a/src/plugins/WorkloadCharacterisation.h
+++ b/src/plugins/WorkloadCharacterisation.h
@@ -42,18 +42,20 @@ public:
   virtual void workItemComplete(const WorkItem *workItem) override;
   virtual void workItemBarrier(const WorkItem *workItem) override;
   virtual void workItemClearBarrier(const WorkItem *workItem) override;
-  
+
   struct ledgerElement {
     size_t address;
     uint32_t timestep;
   };
 private:
+  const KernelInvocation *m_kernelInvocation;
+
   // std::unordered_map<std::pair<size_t, bool>, uint32_t> m_memoryOps;
   std::unordered_map<size_t, uint32_t> m_storeOps;
   std::unordered_map<size_t, uint32_t> m_loadOps;
   std::unordered_map<std::string, size_t> m_computeOps;
-  std::unordered_map<size_t, std::unordered_map<uint16_t, uint32_t>> m_branchPatterns;
-  std::unordered_map<size_t, uint32_t> m_branchCounts;
+  std::unordered_map<const llvm::Instruction *, std::unordered_map<uint16_t, uint32_t>> m_branchPatterns;
+  std::unordered_map<const llvm::Instruction *, uint32_t> m_branchCounts;
   std::vector<uint32_t> m_instructionsToBarrier;
   std::unordered_map<uint16_t, size_t> m_instructionWidth;
   std::vector<uint32_t> m_instructionsPerWorkitem;
@@ -79,10 +81,13 @@ private:
     std::unordered_map<size_t, uint32_t> *storeOps;
     std::unordered_map<size_t, uint32_t> *loadOps;
     // true -> load; false -> store.
+
     bool previous_instruction_is_branch;
-    std::string target1, target2;
-    uint32_t branch_loc;
-    std::unordered_map<size_t, std::vector<bool>> *branchOps;
+    llvm::BasicBlock* target1;
+    llvm::BasicBlock* target2;
+    const llvm::Instruction* branch_loc;
+    std::unordered_map<const llvm::Instruction*, std::vector<bool>> *branchOps;
+
     uint32_t threads_invoked;
     uint32_t barriers_hit;
     uint32_t instruction_count;


### PR DESCRIPTION
Builds on #5 

From https://github.com/Aerijo/AIWC/pull/3

Currently the branch entropy uses source line number to identify each instruction. This has two major issues:

    Debug information is not guaranteed to exist, and a segfault happens when it doesn't
    Branch instructions that share the same source line will have their taken/not taken streams merged.

This identifies branches by their llvm::Instruction pointer, which is unique and shared by all work-items. When it is time to output the metrics it will attempt to use source code line to mark which branch it is (but duplicates may appear if multiple branches shared a line). If not possible, it will currently use the instruction pointer. This is mostly useless though; better is to use a combination of function name + instruction offset perhaps. The kernel details are saved in the AIWC class to allow for this, it's just a matter of matching each branch instruction to it's function and offset.