### PR TITLE
Aiwc logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ config.h
 .ninja_log
 build.ninja
 rules.ninja
+build
 
 # Compiler output
 *.o

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,7 +259,7 @@ set_target_properties(oclgrind PROPERTIES INSTALL_RPATH ${CLANG_ROOT}/lib)
 target_link_libraries(oclgrind PUBLIC ${CORE_EXTRA_LIBS} -Wl,-rpath,${CLANG_ROOT}/lib
   clangFrontend clangSerialization clangDriver clangCodeGen
   clangParse clangSema clangAnalysis clangEdit clangAST clangLex clangBasic
-  "${LLVM_LIBS}" Threads::Threads)
+  "${LLVM_LIBS}" Threads::Threads dl)
 
 if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
   target_link_libraries(oclgrind PRIVATE Version)

--- a/src/plugins/WorkloadCharacterisation.cpp
+++ b/src/plugins/WorkloadCharacterisation.cpp
@@ -368,66 +368,29 @@ vector<double> parallelSpatialLocality(vector < vector < WorkloadCharacterisatio
   return psl;
 }
 
-void WorkloadCharacterisation::kernelEnd(const KernelInvocation *kernelInvocation) {
-  // Load default locale
-  locale previousLocale = cout.getloc();
-  locale defaultLocale("");
-  cout.imbue(defaultLocale);
-
-  cout << endl
-       << "# Architecture-Independent Workload Characterization of kernel: " << kernelInvocation->getKernel()->getName() << endl;
-
-  cout << endl
-       << "## Compute" << endl
-       << endl;
-
+void WorkloadCharacterisation::logMetrics(const KernelInvocation *kernelInvocation) {
   std::vector<std::pair<std::string, size_t>> sorted_ops(m_computeOps.size());
   std::partial_sort_copy(m_computeOps.begin(), m_computeOps.end(), sorted_ops.begin(), sorted_ops.end(), [](const std::pair<std::string, size_t> &left, const std::pair<std::string, size_t> &right) {
     return (left.second > right.second);
   });
 
-  cout << "|" << setw(20) << left << "Opcode"
-       << "|" << setw(12) << right << "count"
-       << "|" << endl;
-  cout << "|--------------------|-----------:|" << endl;
-  for (auto const &item : sorted_ops)
-    cout << "|" << setw(20) << left << item.first << "|" << setw(12) << right << item.second << "|" << endl;
-  cout << endl;
-
   size_t operation_count = 0;
   for (auto const &item : sorted_ops)
     operation_count += item.second;
+
   size_t significant_operation_count = (size_t)ceil(operation_count * 0.9);
   size_t major_operations = 0;
   size_t total_instruction_count = operation_count;
   operation_count = 0;
 
-  cout << "unique opcodes required to cover 90\% of dynamic instructions: ";
   while (operation_count < significant_operation_count) {
-    if (major_operations > 0)
-      cout << ", ";
     operation_count += sorted_ops[major_operations].second;
     cout << sorted_ops[major_operations].first;
     major_operations++;
   }
-  cout << endl
-       << endl;
-
-  cout << "num unique opcodes required to cover 90\% of dynamic instructions: " << major_operations << endl
-       << endl;
-  cout << "Total Instruction Count: " << total_instruction_count << endl;
-
-  cout << endl
-       << "## Parallelism" << endl;
-
-  cout << endl
-       << "### Utilization" << endl
-       << endl;
 
   double freedom_to_reorder = std::accumulate(m_instructionsBetweenLoadOrStore.begin(), m_instructionsBetweenLoadOrStore.end(), 0.0);
   freedom_to_reorder = freedom_to_reorder / m_instructionsBetweenLoadOrStore.size();
-  cout << "Freedom to Reorder: " << setprecision(2) << freedom_to_reorder << endl
-       << endl;
 
   double resource_pressure = 0;
   for (auto const &item : m_storeInstructionLabels)
@@ -435,21 +398,9 @@ void WorkloadCharacterisation::kernelEnd(const KernelInvocation *kernelInvocatio
   for (auto const &item : m_loadInstructionLabels)
     resource_pressure += item.second;
   resource_pressure = resource_pressure / m_threads_invoked;
-  cout << "Resource Pressure: " << setprecision(2) << resource_pressure << endl;
 
-  cout << endl
-       << "### Thread-Level Parallelism" << endl
-       << endl;
-
-  cout << "Work-items: " << m_threads_invoked << endl
-       << endl;
   double granularity = 1.0 / static_cast<double>(m_threads_invoked);
-  cout << "Granularity: " << granularity << endl
-       << endl;
 
-  cout << "Total Barriers Hit: " << m_barriers_hit << endl
-       << endl;
-  //cout << "num barriers hit per thread: " << m_instructionsToBarrier.size()/m_threads_invoked << endl;
   uint32_t itb_min = *std::min_element(m_instructionsToBarrier.begin(), m_instructionsToBarrier.end());
   uint32_t itb_max = *std::max_element(m_instructionsToBarrier.begin(), m_instructionsToBarrier.end());
 
@@ -464,14 +415,7 @@ void WorkloadCharacterisation::kernelEnd(const KernelInvocation *kernelInvocatio
     itb_median = itb[size / 2];
   }
 
-  cout << "Instructions to Barrier (min/max/median): " << itb_min << "/" << itb_max << "/" << itb_median << endl
-       << endl;
   double barriers_per_instruction = static_cast<double>(m_barriers_hit + m_threads_invoked) / static_cast<double>(total_instruction_count);
-  cout << "Barriers per Instruction: " << barriers_per_instruction << endl
-       << endl;
-
-  cout << "### Work Distribution" << endl
-       << endl;
 
   uint32_t ipt_min = *std::min_element(m_instructionsPerWorkitem.begin(), m_instructionsPerWorkitem.end());
   uint32_t ipt_max = *std::max_element(m_instructionsPerWorkitem.begin(), m_instructionsPerWorkitem.end());
@@ -486,11 +430,6 @@ void WorkloadCharacterisation::kernelEnd(const KernelInvocation *kernelInvocatio
   } else {
     ipt_median = ipt[size / 2];
   }
-  cout << "Instructions per Thread (min/max/median): " << ipt_min << "/" << ipt_max << "/" << ipt_median << endl
-       << endl;
-
-  cout << "### Data Parallelism" << endl
-       << endl;
 
   using pair_type = decltype(m_instructionWidth)::value_type;
 
@@ -503,23 +442,14 @@ void WorkloadCharacterisation::kernelEnd(const KernelInvocation *kernelInvocatio
     simd_sum += item.second * item.first;
     simd_num += item.second;
   }
+
   double simd_mean = simd_sum / (double)simd_num;
   std::vector<double> diff(m_instructionWidth.size());
   std::transform(m_instructionWidth.begin(), m_instructionWidth.end(), diff.begin(), [simd_mean](const pair_type &x) { return (x.first - simd_mean) * (x.first - simd_mean) * x.second; });
   double simd_sq_sum = std::accumulate(diff.begin(), diff.end(), 0.0);
   double simd_stdev = std::sqrt(simd_sq_sum / (double)simd_num);
-  cout << "SIMD Width (min/max/mean/stdev): " << simd_min << "/" << simd_max << "/" << simd_mean << "/" << simd_stdev << endl
-       << endl;
 
   double instructions_per_operand = static_cast<double>(total_instruction_count) / simd_sum;
-  cout << "Instructions per Operand: " << instructions_per_operand << endl
-       << endl;
-
-  cout << "## Memory" << endl
-       << endl;
-
-  cout << "### Memory Footprint" << endl
-       << endl;
 
   // count accesses to memory addresses with different numbers of retained
   // significant bits
@@ -560,22 +490,7 @@ void WorkloadCharacterisation::kernelEnd(const KernelInvocation *kernelInvocatio
     //cout << "address: "<< e.first << " accessed: " << e.second << " times!" << endl;
   }
 
-  cout << "num memory accesses: " << memory_access_count << endl
-       << endl;
-  cout << "Total Memory Footprint -- num unique memory addresses accessed: " << local_address_count[0].size() << endl;
-  cout << "                          num unique memory addresses read:     " << m_storeOps.size() << endl;
-  cout << "                          num unique memory addresses written:  " << m_loadOps.size()  << endl;
-  cout << "                          unique read/write ratio:              "
-       << setprecision(4) << (float) (((double)m_loadOps.size()) / ((double)m_storeOps.size()))  << endl;
-  cout << "                          total reads:                          " << load_count    << endl;
-  cout << "                          total writes:                         " << store_count    << endl;
-  cout << "                          re-reads:                             " << setprecision(4)
-       << (float)((double)load_count / (double)m_loadOps.size()) << endl;
-  cout << "                          re-writes:                            " << setprecision(4)
-       << (float)((double)store_count / (double)m_storeOps.size()) << endl << endl;
   size_t significant_memory_access_count = (size_t)ceil(memory_access_count * 0.9);
-  cout << "90\% of memory accesses: " << significant_memory_access_count << endl
-       << endl;
 
   size_t unique_memory_addresses = 0;
   size_t access_count = 0;
@@ -583,15 +498,6 @@ void WorkloadCharacterisation::kernelEnd(const KernelInvocation *kernelInvocatio
     access_count += sorted_count[unique_memory_addresses].second;
     unique_memory_addresses++;
   }
-  cout << "90% Memory Footprint -- num unique memory addresses that cover 90\% of memory accesses: " << unique_memory_addresses << endl
-       << endl;
-  //cout << "the top 10:" << endl;
-  //for (int i = 0; i < 10; i++){
-  //    cout << "address: " << sorted_count[i].first << " contributed: " << sorted_count[i].second << " accesses!" << endl;
-  //}
-
-  cout << "### Memory Entropy" << endl
-       << endl;
 
   double mem_entropy = 0.0;
   for (const auto &it : sorted_count) {
@@ -599,16 +505,7 @@ void WorkloadCharacterisation::kernelEnd(const KernelInvocation *kernelInvocatio
     double prob = (double)value * 1.0 / (double)memory_access_count;
     mem_entropy = mem_entropy - prob * std::log2(prob);
   }
-  cout << "Global Memory Address Entropy -- measure of the randomness of memory addresses: " << (float)mem_entropy << endl
-       << endl;
 
-  cout << "Local Memory Address Entropy -- measure of the spatial locality of memory addresses" << endl
-       << endl;
-
-  cout << "|" << setw(12) << right << "LSBs skipped"
-       << "|" << setw(8) << right << "Entropy"
-       << "|" << endl;
-  cout << "|-----------:|-------:|" << endl;
   std::vector<float> loc_entropy;
   for (int nskip = 1; nskip < 11; nskip++) {
     double local_entropy = 0.0;
@@ -617,18 +514,7 @@ void WorkloadCharacterisation::kernelEnd(const KernelInvocation *kernelInvocatio
       local_entropy = local_entropy - prob * std::log2(prob);
     }
     loc_entropy.push_back((float)local_entropy);
-    cout << "|" << setw(12) << right << nskip << "|" << fixed << setw(8) << setprecision(4) << right << (float)local_entropy << "|" << endl;
   }
-
-  cout << endl
-       << "### Parallel Spatial Locality" << endl
-       << endl;
-
-
-  cout << "|" << setw(12) << right << "LSBs skipped"
-       << "|" << setw(25) << right << "Normed Parallel Spatial Locality"
-       << "|" << endl;
-  cout << "|-----------:|------------------------:|" << endl;
 
   vector<double> avg_psl = vector<double>();
   double avg_psl_sum = 0.0;
@@ -641,36 +527,9 @@ void WorkloadCharacterisation::kernelEnd(const KernelInvocation *kernelInvocatio
     avg_psl_i = (avg_psl_i / double(m_psl_per_group.size())) / std::log2(double(items_per_group + 1));
     avg_psl.push_back(avg_psl_i);
     avg_psl_sum += avg_psl_i;
-    cout << "|" << setw(12) << right << i << "|" << fixed << setw(25) << setprecision(4) << right << (float)avg_psl_i << "|" << endl;
   }
 
-  cout << endl
-       << "Normed Locality Sum: " << avg_psl_sum
-       << endl;
-
-  cout << endl
-       << "### Memory Diversity -- Usage of local and constant memory relative to global memory" << endl
-       << endl;
-
-  cout << "num global memory accesses: " << m_global_memory_access << endl
-       << endl;
-  cout << "num local memory accesses: " << m_local_memory_access << endl
-       << endl;
-  cout << "num constant memory accesses: " << m_constant_memory_access << endl
-       << endl;
-
   uint32_t m_total_memory_access = m_global_memory_access + m_local_memory_access + m_constant_memory_access;
-
-  cout << "\% local memory accesses (local/total): " << setprecision(2) << (((float)m_local_memory_access / (float)m_total_memory_access) * 100) << endl
-       << endl;
-  cout << "\% constant memory accesses (constant/total): " << setprecision(2) << (((float)m_constant_memory_access / (float)m_total_memory_access) * 100) << endl
-       << endl;
-
-  cout << "## Control" << endl
-       << endl;
-
-  cout << "Unique Branch Instructions -- Total number of unique branch instructions to cover 90\% of the branches" << endl
-       << endl;
 
   auto instruction_to_id = [](const llvm::Instruction* instruction) -> size_t {
     const llvm::DebugLoc& loc = instruction->getDebugLoc();
@@ -700,16 +559,10 @@ void WorkloadCharacterisation::kernelEnd(const KernelInvocation *kernelInvocatio
     return left.first < right.first;
   });
 
-  cout << "|" << setw(14) << left << "Branch At Line"
-       << "|" << setw(23) << right << "Count (hit and miss)"
-       << "|" << endl;
-  cout << "|--------------|----------------------:|" << endl;
   size_t branch_op_count = 0;
   for (auto const &x : sorted_branch_ops) {
     branch_op_count += x.second;
-    cout << "|" << setw(14) << left << x.first << "|" << setw(23) << right << x.second << "|" << endl;
   }
-  cout << endl;
 
   size_t significant_branch_op_count = (size_t)ceil(branch_op_count * 0.9);
 
@@ -719,11 +572,6 @@ void WorkloadCharacterisation::kernelEnd(const KernelInvocation *kernelInvocatio
     branch_count += sorted_branch_ops[unique_branch_addresses].second;
     unique_branch_addresses++;
   }
-  cout << "Number of unique branches that cover 90\% of all branch instructions: " << unique_branch_addresses << endl;
-
-  cout << endl
-       << "### Branch Entropy -- measure of the randomness of branch behaviour, representing branch predictability" << endl
-       << endl;
 
   //generate a history pattern
   //(arbitarily selected to a history of m=16 branches?)
@@ -759,36 +607,55 @@ void WorkloadCharacterisation::kernelEnd(const KernelInvocation *kernelInvocatio
       N += number_of_occurrences;
     }
   }
+
   average_entropy = average_entropy / N;
   if (isnan(average_entropy)) {
     average_entropy = 0.0;
   }
-  cout << "Using a branch history of " << m << endl
-       << endl;
-  cout << "Yokota Branch Entropy: " << yokota_entropy << endl
-       << endl;
-  cout << "Yokota Branch Entropy per Workload: " << yokota_entropy_per_workload << endl
-       << endl;
-  cout << "Average Linear Branch Entropy: " << average_entropy << endl
-       << endl;
 
   std::string logfile_name;
 
   const char *result_path = getenv("OCLGRIND_WORKLOAD_CHARACTERISATION_OUTPUT_PATH");
-  if (result_path != NULL){
+  const char *result_dir = getenv("OCLGRIND_WORKLOAD_CHARACTERISATION_OUTPUT_DIR");
+  if (result_path != nullptr) {
+    if (result_dir != nullptr) {
+      std::cerr << "[AIWC warning] both output path and directory set, using path" << std::endl;
+    }
     logfile_name = std::string(result_path);
-  }else{
+  } else {
+    std::string prefix = "";
+    if (result_dir != nullptr) {
+      prefix = std::string(result_dir) + "/";
+    }
+
     int logfile_count = 0;
-    logfile_name = "aiwc_" + kernelInvocation->getKernel()->getName() + "_" + std::to_string(logfile_count) + ".csv";
-    while (std::ifstream(logfile_name)) {
+
+    while (true) {
+      logfile_name = prefix + "aiwc_" + kernelInvocation->getKernel()->getName() + "_" + std::to_string(logfile_count) + ".csv";
+      if (!std::ifstream(logfile_name)) {
+        break;
+      }
       logfile_count++;
-      logfile_name = "aiwc_" + kernelInvocation->getKernel()->getName() + "_" + std::to_string(logfile_count) + ".csv";
     }
   }
+
   std::ofstream logfile;
-  logfile.open(logfile_name);
-  assert(logfile);
+  logfile.open(logfile_name, std::ios::ate); // sppend to file
+
+  if (!logfile.is_open()) {
+    std::cerr << "[AIWC error] Failed to open file for logging \"" << logfile_name << "\"" << std::endl;
+    return;
+  }
+
   logfile << "metric,category,count\n";
+  logfile << "kernel_name,Meta," << kernelInvocation->getKernel()->getName() << "\n";
+
+  logfile << "OpcodeCounts,Compute,";
+  for (const auto &item : sorted_ops) {
+    logfile << item.first << "=" << item.second << ";";
+  }
+  logfile << "\n";
+
   logfile << "Opcode,Compute," << major_operations << "\n";
   logfile << "Total Instruction Count,Compute," << total_instruction_count << "\n";
   logfile << "Freedom to Reorder,Compute," << freedom_to_reorder << "\n";
@@ -804,12 +671,14 @@ void WorkloadCharacterisation::kernelEnd(const KernelInvocation *kernelInvocatio
   logfile << "Min IPT,Parallelism," << ipt_min << "\n";
   logfile << "Max IPT,Parallelism," << ipt_max << "\n";
   logfile << "Median IPT,Parallelism," << ipt_median << "\n";
-  logfile << "Max SIMD Width,Parallelism," << std::max_element(m_instructionWidth.begin(), m_instructionWidth.end(), [](const pair_type &a, const pair_type &b) { return a.first < b.first; })->first << "\n";
+  logfile << "Min SIMD Width,Parallelism," << simd_min << "\n";
+  logfile << "Max SIMD Width,Parallelism," << simd_max << "\n";
   logfile << "Mean SIMD Width,Parallelism," << simd_mean << "\n";
   logfile << "SD SIMD Width,Parallelism," << simd_stdev << "\n";
   logfile << "Granularity,Parallelism," << granularity << "\n";
   logfile << "Barriers Per Instruction,Parallelism," << barriers_per_instruction << "\n";
   logfile << "Instructions Per Operand,Parallelism," << instructions_per_operand << "\n";
+  logfile << "Num Memory Accesses,Memory," << memory_access_count << "\n";
   logfile << "Total Memory Footprint,Memory," << local_address_count[0].size() << "\n";
   logfile << "Unique Memory Accesses,Memory," << local_address_count[0].size() << "\n";
   logfile << "Unique Reads,Memory," << m_storeOps.size() << "\n";
@@ -835,16 +704,26 @@ void WorkloadCharacterisation::kernelEnd(const KernelInvocation *kernelInvocatio
   logfile << "Total Constant Memory Accessed,Memory," << m_constant_memory_access << "\n";
   logfile << "Relative Local Memory Usage,Memory," << (((float)m_local_memory_access / (float)m_total_memory_access) * 100) << "\n";
   logfile << "Relative Constant Memory Usage,Memory," << (((float)m_constant_memory_access / (float)m_total_memory_access) * 100) << "\n";
+
+  logfile << "Branch Counts,Control,";
+  for (auto const &item : sorted_branch_ops) {
+    logfile << item.first << "=" << item.second << ";";
+  }
+  logfile << "\n";
+
   logfile << "Total Unique Branch Instructions,Control," << sorted_branch_ops.size() << "\n";
   logfile << "90\% Branch Instructions,Control," << unique_branch_addresses << "\n";
+  logfile << "Branch History Size,Memory," << m << "\n";
   logfile << "Yokota Branch Entropy,Memory," << yokota_entropy_per_workload << "\n";
   logfile << "Average Linear Branch Entropy,Memory," << average_entropy << "\n";
+
   logfile.close();
 
-  cout << endl
-       << "The Architecture-Independent Workload Characterisation was written to file: " << logfile_name << endl;
-  // Restore locale
-  cout.imbue(previousLocale);
+  cout << "The Architecture-Independent Workload Characterisation was written to file: " << logfile_name << endl;
+}
+
+void WorkloadCharacterisation::kernelEnd(const KernelInvocation *kernelInvocation) {
+  logMetrics(kernelInvocation);
 
   // Reset kernel counts, ready to start anew
   //m_memoryOps.clear();

--- a/src/plugins/WorkloadCharacterisation.cpp
+++ b/src/plugins/WorkloadCharacterisation.cpp
@@ -640,7 +640,7 @@ void WorkloadCharacterisation::logMetrics(const KernelInvocation *kernelInvocati
   }
 
   std::ofstream logfile;
-  logfile.open(logfile_name, std::ios::ate); // sppend to file
+  logfile.open(logfile_name, std::ios::app); // sppend to file
 
   if (!logfile.is_open()) {
     std::cerr << "[AIWC error] Failed to open file for logging \"" << logfile_name << "\"" << std::endl;

--- a/src/plugins/WorkloadCharacterisation.cpp
+++ b/src/plugins/WorkloadCharacterisation.cpp
@@ -647,12 +647,15 @@ void WorkloadCharacterisation::logMetrics(const KernelInvocation *kernelInvocati
     return;
   }
 
+  std::string list_delim = ";";
+  std::string keyval_sep = "=";
+
   logfile << "metric,category,count\n";
   logfile << "kernel_name,Meta," << kernelInvocation->getKernel()->getName() << "\n";
 
   logfile << "OpcodeCounts,Compute,";
   for (const auto &item : sorted_ops) {
-    logfile << item.first << "=" << item.second << ";";
+    logfile << item.first << keyval_sep << item.second << list_delim;
   }
   logfile << "\n";
 
@@ -692,12 +695,19 @@ void WorkloadCharacterisation::logMetrics(const KernelInvocation *kernelInvocati
 
   logfile << "90\% Memory Footprint,Memory," << unique_memory_addresses << "\n";
   logfile << "Global Memory Address Entropy,Memory," << mem_entropy << "\n";
+
+  logfile << "LMAE,Memory,";
   for (int nskip = 1; nskip < 11; nskip++) {
-    logfile << "LMAE -- Skipped " << nskip << " LSBs,Memory," << loc_entropy[nskip - 1] << "\n";
+    logfile << nskip << keyval_sep << loc_entropy[nskip - 1] << list_delim;
   }
+  logfile << "\n";
+
+  logfile << "Normed PSL,Memory,";
   for (int nskip = 0; nskip < 11; nskip++) {
-    logfile << "Normed PSL -- Skipped " << nskip << " LSBs,Memory," << avg_psl[nskip] << "\n";
+    logfile << nskip << keyval_sep << avg_psl[nskip] << list_delim;
   }
+  logfile << "\n";
+
   logfile << "Normed PSL Sum,Memory," << avg_psl_sum << "\n";
   logfile << "Total Global Memory Accessed,Memory," << m_global_memory_access << "\n";
   logfile << "Total Local Memory Accessed,Memory," << m_local_memory_access << "\n";
@@ -707,7 +717,7 @@ void WorkloadCharacterisation::logMetrics(const KernelInvocation *kernelInvocati
 
   logfile << "Branch Counts,Control,";
   for (auto const &item : sorted_branch_ops) {
-    logfile << item.first << "=" << item.second << ";";
+    logfile << item.first << keyval_sep << item.second << list_delim;
   }
   logfile << "\n";
 

--- a/src/plugins/WorkloadCharacterisation.h
+++ b/src/plugins/WorkloadCharacterisation.h
@@ -42,18 +42,20 @@ public:
   virtual void workItemComplete(const WorkItem *workItem) override;
   virtual void workItemBarrier(const WorkItem *workItem) override;
   virtual void workItemClearBarrier(const WorkItem *workItem) override;
-  
+
   struct ledgerElement {
     size_t address;
     uint32_t timestep;
   };
 private:
+  const KernelInvocation *m_kernelInvocation;
+
   // std::unordered_map<std::pair<size_t, bool>, uint32_t> m_memoryOps;
   std::unordered_map<size_t, uint32_t> m_storeOps;
   std::unordered_map<size_t, uint32_t> m_loadOps;
   std::unordered_map<std::string, size_t> m_computeOps;
-  std::unordered_map<size_t, std::unordered_map<uint16_t, uint32_t>> m_branchPatterns;
-  std::unordered_map<size_t, uint32_t> m_branchCounts;
+  std::unordered_map<const llvm::Instruction *, std::unordered_map<uint16_t, uint32_t>> m_branchPatterns;
+  std::unordered_map<const llvm::Instruction *, uint32_t> m_branchCounts;
   std::vector<uint32_t> m_instructionsToBarrier;
   std::unordered_map<uint16_t, size_t> m_instructionWidth;
   std::vector<uint32_t> m_instructionsPerWorkitem;
@@ -79,10 +81,13 @@ private:
     std::unordered_map<size_t, uint32_t> *storeOps;
     std::unordered_map<size_t, uint32_t> *loadOps;
     // true -> load; false -> store.
+
     bool previous_instruction_is_branch;
-    std::string target1, target2;
-    uint32_t branch_loc;
-    std::unordered_map<size_t, std::vector<bool>> *branchOps;
+    llvm::BasicBlock* target1;
+    llvm::BasicBlock* target2;
+    const llvm::Instruction* branch_loc;
+    std::unordered_map<const llvm::Instruction*, std::vector<bool>> *branchOps;
+
     uint32_t threads_invoked;
     uint32_t barriers_hit;
     uint32_t instruction_count;

--- a/src/plugins/WorkloadCharacterisation.h
+++ b/src/plugins/WorkloadCharacterisation.h
@@ -43,6 +43,8 @@ public:
   virtual void workItemBarrier(const WorkItem *workItem) override;
   virtual void workItemClearBarrier(const WorkItem *workItem) override;
 
+  void logMetrics(const KernelInvocation *kernelInvocation);
+
   struct ledgerElement {
     size_t address;
     uint32_t timestep;


### PR DESCRIPTION
Builds on #6 

See https://github.com/Aerijo/AIWC/pull/4 https://github.com/Aerijo/AIWC/pull/5

Initial AIWC logging change. 

- Consolidates the output into the logfile values. No duplication between console and logfile stats
- `OCLGRIND_WORKLOAD_CHARACTERISATION_OUTPUT_PATH` will now append to existing file (may have multiple kernel results appended)
- `OCLGRIND_WORKLOAD_CHARACTERISATION_OUTPUT_DIR` offered as alternative, will put automatically named file in this directory (unique file per kernel).
- Prints kernel name as metric
- Removed locale usage. Would really prefer not to use locales, as it causes crashes when locales aren't installed (e.g., in docker image).
- List metrics printed as lists (key-val separator and list item separator configurable).

A separate PR will remove redundant log lines (ones derived from other metrics) and provide a script to print the markdown report + compare runs.